### PR TITLE
Start migration in code to allow multiple minigame sessions to be played at once

### DIFF
--- a/mob_survival/init.lua
+++ b/mob_survival/init.lua
@@ -49,74 +49,11 @@ arena_lib.register_minigame("mob_survival", {
     }
 )
 
-mob_survival.player_queue = {}
-
-minetest.register_on_joinplayer(function(player)
-  local name = player:get_player_name()
-  minetest.chat_send_player(name, "Welcome to the minigame Mob Survival! You have now been queued for the next game. "..
-  "If you want to leave the queue and go back to the lobby, use the command /leave")
-  local id, arena = arena_lib.get_arena_by_name("mob_survival", "sphinx")
-  if not arena.in_game and arena.players_amount < 4 then
-    arena_lib.join_queue("mob_survival", arena, name)
-  else
-    table.insert(mob_survival.player_queue, name)
-  end
-end)
-
-local function hop_player_to_lobby(name)
-  tribyu_api.msp.hop_player(name, "Lobby", function(success, data)
-      if success then -- API call success 
-          if data.success then -- Hop success
-              core.log("action", "hop_player success")
-          else -- Hop failed, check reason
-              core.log("warning", "hop_player fail: " .. data.reason)
-          end
-      elseif data then -- API call returned failed status with known reason
-          core.log("error", "hop_player fail: " .. data.reason)
-      else -- API call failed with unknown reason (most likely server or network issues)
-          core.log("error", "hop_player api call failure")
-      end
-  end)
-end
-
-minetest.register_chatcommand("leave", {
-  description = "Leave the match/queue",
-  func = function(name)
-    if arena_lib.is_player_playing(name, "mob_survival") then
-      local id, arena = arena_lib.get_arena_by_name("mob_survival","sphinx")
-      arena_lib.remove_player_from_arena(name, 3, "Server")
-      --hop_player_to_lobby(name)
-    else
-      local player_in_mob_survival_queue = false
-      local index
-      for i, pl_name in pairs(mob_survival.player_queue) do
-        if pl_name == name then
-          player_in_mob_survival_queue = true
-          index = i
-        end
-      end
-      if player_in_mob_survival_queue then
-        table.remove(mob_survival.player_queue, index)
-      else
-        arena_lib.remove_player_from_queue(name)
-      end
-    end
-  end
-})
-
-arena_lib.register_on_leave_queue(function(mod, arena, p_name, has_queue_status_changed)
-  --hop_player_to_lobby(p_name)
-end)
-
-arena_lib.on_join_queue("mob_survival", function(arena, p_name)
-  if arena.players_amount == 4 then
-    arena_lib.force_start(nil, "mob_survival", arena)
-  end
-end)
 mob_survival.path = minetest.get_modpath(minetest.get_current_modname())
 
 dofile(mob_survival.path.."/src/files_loader.lua")
 dofile(mob_survival.path.."/src/api.lua")
 dofile(mob_survival.path.."/src/shop.lua")
 dofile(mob_survival.path.."/src/shopkeeper.lua")
+dofile(mob_survival.path.."/src/travelguide.lua")
 dofile(mob_survival.path.."/src/arena_manager.lua")

--- a/mob_survival/init.lua
+++ b/mob_survival/init.lua
@@ -40,6 +40,7 @@ arena_lib.register_minigame("mob_survival", {
     is_team_chat_default = false,
     end_when_too_few = false,
     show_nametags = true,
+    regenerate_map = true,
     spectate_mode = "blind",
     min_players = 1,
     hotbar = {

--- a/mob_survival/src/arena_manager.lua
+++ b/mob_survival/src/arena_manager.lua
@@ -198,25 +198,10 @@ function on_time_tick(arena)
     end
 
     local restart_time_tick = true
-
-    for pl_name, _ in pairs(arena.players) do
-        local player = minetest.get_player_by_name(pl_name)
-        local p_meta = player:get_meta()
-
-        local players_eliminated = 0
-
-        if p_meta:get_int("eliminated") == 1 then
-            players_eliminated = players_eliminated + 1
-            if players_eliminated == tablelen(arena.players) then
-                arena_lib.force_end("Server", "mob_survival", arena)
-                restart_time_tick = false
-            end
-        end
-    end
-    if tablelen(arena.players) == 0 then
-        arena_lib.force_end("Server", "mob_survival", arena)
+    if arena.players_amount == 0 then
         restart_time_tick = false
     end
+
     if restart_time_tick then
         minetest.after(1, function()
             on_time_tick(arena)

--- a/mob_survival/src/arena_manager.lua
+++ b/mob_survival/src/arena_manager.lua
@@ -249,15 +249,15 @@ arena_lib.on_death("mob_survival", function(arena, p_name, reason)
             local spectate_player = minetest.get_player_by_name(ps_name)
             arena_lib.spectate_target("mob_survival", arena, p_name, spectate_player, spectate_player:get_player_name())
             arena.spectators[p_name].diff_on_elim = arena.diff
-            check_for_respawn(p_name)
+            check_for_respawn(p_name, arena.name)
             break
         end
     end
 end)
 
-function check_for_respawn(pl_name)
+function check_for_respawn(pl_name, arena_name)
     local player = minetest.get_player_by_name(pl_name)
-    local id, arena = arena_lib.get_arena_by_name("mob_survival", "sphinx")
+    local id, arena = arena_lib.get_arena_by_name("mob_survival", arena_name)
     if not arena.spectators[pl_name] then return end -- Check if player left using the leave item
     local diff_on_elim = arena.spectators[pl_name].diff_on_elim
 
@@ -283,8 +283,8 @@ function check_for_respawn(pl_name)
         end
         if restart_respawn_check then
             minetest.after(1, function()
-                check_for_respawn(pl_name)
-            end, pl_name)
+                check_for_respawn(pl_name, arena_name)
+            end, pl_name, arena_name)
         end
     end
 end
@@ -410,6 +410,8 @@ arena_lib.on_end("mob_survival", function(arena, winners, is_forced)
         end
     end
     mob_survival.moblist = {}
+
+    arena_lib.hard_reset_map("server", "mob_survival", arena.name)
 
     for pl_name, _ in pairs(all_players) do
         local player = minetest.get_player_by_name(pl_name)

--- a/mob_survival/src/arena_manager.lua
+++ b/mob_survival/src/arena_manager.lua
@@ -32,6 +32,24 @@ mob_survival.moblist = {}
 
 local mobnames = keyset(mob_survival.mobdiffs)
 
+mob_survival.register_global_callback(function(mob_name, killer)
+    local p_meta = killer:get_meta()
+    if p_meta then
+      local gold = p_meta:get_int("gold")
+  
+      if mob_survival.mob_kills_gold[mob_name] then
+        local addition = mob_survival.mob_kills_gold[mob_name]
+        p_meta:set_int("gold", gold+addition)
+        local mob_human_name = split(mob_name, ":")[2]
+        arena_lib.HUD_send_msg("hotbar", killer:get_player_name(), "You just got "..addition.." gold for killing a "..mob_human_name.."!")
+        p_meta:set_int("is_kill_HUD_active", 1)
+        minetest.after(2, function(p_meta)
+            p_meta:set_int("is_kill_HUD_active", 0)
+        end, p_meta)
+      end
+    end
+end)
+
 arena_lib.on_join("mob_survival", function(p_name, arena, as_spectator, was_spectator)
     local inv = minetest.get_player_by_name(p_name):get_inventory()
     if as_spectator then return end
@@ -380,35 +398,6 @@ function split(inputstr, sep)
     return t
 end
 
-mob_survival.register_global_callback(function(mob_name, killer)
-    local p_meta = killer:get_meta()
-    if p_meta then
-      local gold = p_meta:get_int("gold")
-  
-      if mob_survival.mob_kills_gold[mob_name] then
-        local addition = mob_survival.mob_kills_gold[mob_name]
-        p_meta:set_int("gold", gold+addition)
-        local mob_human_name = split(mob_name, ":")[2]
-        arena_lib.HUD_send_msg("hotbar", killer:get_player_name(), "You just got "..addition.." gold for killing a "..mob_human_name.."!")
-        p_meta:set_int("is_kill_HUD_active", 1)
-        minetest.after(2, function(p_meta)
-            p_meta:set_int("is_kill_HUD_active", 0)
-        end, p_meta)
-      end
-    end
-  end)
-
-local slots_available
-
-local function reshow_formmspec(formspec, pl_name, p_meta)
-    if p_meta:get_int("button_clicked") == 0 then
-        core.show_formspec(pl_name, "mob_survival:play_again", formspec)
-        minetest.after(0.2, function(formspec, pl_name, p_meta)
-            reshow_formmspec(formspec, pl_name, p_meta)
-        end, formspec, pl_name, p_meta)
-    end
-end
-
 arena_lib.on_end("mob_survival", function(arena, winners, is_forced)
     if is_forced then
         arena.shopkeeper:remove()
@@ -445,77 +434,6 @@ arena_lib.on_end("mob_survival", function(arena, winners, is_forced)
                 end
             else
                 minetest.chat_send_player(pl_name, "You haven't beaten your highscore :(.")
-            end
-
-
-            local text = "Everyone was eliminated, so the game ends! Would you like to play again?"
-            
-            local formspecstr = {
-                "formspec_version[4]",
-                "size[6,5]",
-                "label[0.375,0.5;Game over!]",
-                "hypertext[0.375,1.25;5.25,2;gameovertext;",core.formspec_escape(text),"]",
-                "button_exit[0.25,3.5;3.5,1.1;back;Go back to lobby]",
-                "button_exit[4,3.5;1.75,1.1;play;Play again!]"
-            }
-
-            local formspec = table.concat(formspecstr, "")
-
-            core.show_formspec(pl_name, "mob_survival:play_again", formspec)
-
-            p_meta:set_int("button_clicked", 0)
-            minetest.after(0.2, function(formspec, pl_name, p_meta)
-                reshow_formmspec(formspec, pl_name, p_meta)
-            end, formspec, pl_name, p_meta)
-        end
-    end
-
-    total_players = 4
-    slots_available = 0
-end)
-
-local function hop_player_to_lobby(name)
-    tribyu_api.msp.hop_player(name, "Lobby", function(success, data)
-        if success then -- API call success 
-            if data.success then -- Hop success
-                core.log("action", "hop_player success")
-            else -- Hop failed, check reason
-                core.log("warning", "hop_player fail: " .. data.reason)
-            end
-        elseif data then -- API call returned failed status with known reason
-            core.log("error", "hop_player fail: " .. data.reason)
-        else -- API call failed with unknown reason (most likely server or network issues)
-            core.log("error", "hop_player api call failure")
-        end
-    end)
-end
-
-minetest.register_on_player_receive_fields(function(player, formname, fields)
-    local name = player:get_player_name()
-    local p_meta = player:get_meta()
-    for field, _ in pairs(fields) do
-        if field == "play" then
-            p_meta:set_int("button_clicked", 1)
-            local id, arena = arena_lib.get_arena_by_name("mob_survival", "sphinx")
-            arena_lib.join_queue("mob_survival", arena, name)
-        end
-		if field == "back" then
-            p_meta:set_int("button_clicked", 1)
-            slots_available = slots_available + 1
-            --hop_player_to_lobby(name)
-        end
-    end
-
-    if total_players then
-        total_players = total_players - 1
-    end
-
-    if total_players == 0 then
-        for i = 1, slots_available do
-            if mob_survival.player_queue[1] then
-                local id, arena = arena_lib.get_arena_by_name("mob_survival", "sphinx")
-                arena_lib.join_queue("mob_survival", arena, mob_survival.player_queue[1])
-                table.remove(mob_survival.player_queue, 1)
             end
         end
     end

--- a/mob_survival/src/shopkeeper.lua
+++ b/mob_survival/src/shopkeeper.lua
@@ -1,4 +1,4 @@
-local shopkeeper= {
+local shopkeeper = {
   initial_properties = {
     hp_max = 100,
     physical = true,
@@ -9,12 +9,8 @@ local shopkeeper= {
     nametag = "Shopkeeper"
   },
 
-  -- where we'll store the arena associated to the king, to use it in the callbacks
-  -- that follow
   arena = {},
 
-  -- if the server crashes, we instantly remove the leftover king (staticdata is
-  -- the arena name only when spawned by this mod; there is no get_staticdata())
   on_activate = function(self, staticdata, dtime_s)
     if staticdata == "" then
       self.object:remove()

--- a/mob_survival/src/travelguide.lua
+++ b/mob_survival/src/travelguide.lua
@@ -1,0 +1,70 @@
+function mob_survival.open_travel_page(player) end
+
+local travelguide = {
+    initial_properties = {
+        hp_max = 100,
+        physical = true,
+        collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+        visual = "mesh",
+        mesh = "character.b3d",
+        textures = {"character.png"},
+        nametag = "Travel Guide"
+    },
+  
+    on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)
+        mob_survival.open_travel_page(puncher)
+        return true
+    end,
+    
+    on_rightclick = function(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)
+        mob_survival.open_travel_page(puncher)
+        return true
+    end,
+}
+  
+minetest.register_entity("mob_survival:travelguide", travelguide)
+
+function mob_survival.open_travel_page(player)
+    local text = "Where would you like to travel to?"
+    local formspecstr = {
+        "formspec_version[4]",
+        "size[6,5]",
+        "label[0.375,0.5;Traveling...]",
+        "hypertext[0.375,1.25;5.25,2;gameovertext;",core.formspec_escape(text),"]",
+        "button_exit[0.25,3.5;1.5,1.1;Lobby;Lobby]",
+        "button_exit[2,3.5;1.75,1.1;Orbiter;Orbiters]",
+        "button_exit[4,3.5;1.75,1.1;Overworld;Overworld]"
+    }
+    
+    local formspec = table.concat(formspecstr, "")
+end
+
+local function hop_player(name, place)
+    tribyu_api.msp.hop_player(name, place, function(success, data)
+        if success then -- API call success 
+            if data.success then -- Hop success
+                core.log("action", "hop_player success")
+            else -- Hop failed, check reason
+                core.log("warning", "hop_player fail: " .. data.reason)
+            end
+        elseif data then -- API call returned failed status with known reason
+            core.log("error", "hop_player fail: " .. data.reason)
+        else -- API call failed with unknown reason (most likely server or network issues)
+            core.log("error", "hop_player api call failure")
+        end
+    end)
+end
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	local pl_name = player:get_player_name()
+    
+    local inv = player:get_inventory()
+    local p_meta = player:get_meta()
+
+	for field, _ in pairs(fields) do
+        if field == "Overworld" or field == "Orbiter" or field == "Lobby" then
+            hop_player(pl_name, field)
+        end
+	end
+	return false
+end)

--- a/mob_survival_depends/rangedweapons/aa12.lua
+++ b/mob_survival_depends/rangedweapons/aa12.lua
@@ -43,7 +43,7 @@ minetest.register_tool("rangedweapons:aa12_rrr", {
 		gun_damage = {fleshy=1,knockback=0.25},
 		gun_crit = 5,
 		gun_critEffc = 2.0,
-		suitable_ammo = {{"rangedweapons:shell",20}},
+		suitable_ammo = {{"rangedweapons:shell",10}},
 		gun_skill = {"shotgun_skill",40},
 		gun_magazine = "rangedweapons:drum_mag",
 		gun_unloaded = "rangedweapons:aa12_r",


### PR DESCRIPTION
This PR removes the play again formspec, as there will be a lobby where players can queue for a game.
This PR will also add an travel guide to allow players to go back to other worlds in Satlantis.
This also resets the map after a minigame has been played (TODO: Check if this causes lag).